### PR TITLE
DEV-1867: Fix replication failures for some servers

### DIFF
--- a/binlogreplication/binlog_replica_applier.go
+++ b/binlogreplication/binlog_replica_applier.go
@@ -25,11 +25,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/apecloud/myduckserver/adapter"
-	"github.com/apecloud/myduckserver/binlog"
-	"github.com/apecloud/myduckserver/charset"
-	"github.com/apecloud/myduckserver/delta"
-	"github.com/apecloud/myduckserver/mysqlutil"
 	gms "github.com/dolthub/go-mysql-server"
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/binlogreplication"
@@ -43,6 +38,12 @@ import (
 	"vitess.io/vitess/go/mysql/sqlerror"
 	"vitess.io/vitess/go/sqltypes"
 	vquery "vitess.io/vitess/go/vt/proto/query"
+
+	"github.com/apecloud/myduckserver/adapter"
+	"github.com/apecloud/myduckserver/binlog"
+	"github.com/apecloud/myduckserver/charset"
+	"github.com/apecloud/myduckserver/delta"
+	"github.com/apecloud/myduckserver/mysqlutil"
 )
 
 // positionStore is a singleton instance for loading/saving binlog position state to disk for durable storage.
@@ -1199,11 +1200,12 @@ func (a *binlogReplicaApplier) appendRowFormatChanges(
 		txnGroup = []byte(gtid.File)
 		txnSeq = uint64(gtid.Pos)
 	case replication.MariadbGTID:
-		var domain, server [4]byte
-		binary.BigEndian.PutUint32(domain[:], gtid.Domain)
-		binary.BigEndian.PutUint32(server[:], gtid.Server)
-		txnTag = domain[:]
-		txnServer = server[:]
+		// If you change the following, make sure txnTag & txnServer are valid UTF-8 strings.
+		// Otherwise, we get the following error during the delta buffer flush:
+		//   "Failed to flush changelog: Invalid Input Error: Invalid unicode
+		//   (byte sequence mismatch) detected in segment statistics update"
+		txnTag = strconv.AppendUint(nil, uint64(gtid.Domain), 10)
+		txnServer = strconv.AppendUint(nil, uint64(gtid.Server), 10)
 		txnSeq = gtid.Sequence
 	}
 

--- a/delta/arrow_test.go
+++ b/delta/arrow_test.go
@@ -1,0 +1,174 @@
+// Copyright 2025 SkySQL, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package delta_test
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"fmt"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/marcboeker/go-duckdb"
+)
+
+/*
+Example is as demonstration of how to read the data from an Arrow view.
+
+This can be very useful when debugging the DeltaAppender.
+For that, after a call to DeltaController.prepareArrowView(), you can simply do:
+
+```go
+
+	viewRows, err := tx.QueryContext(ctx, "SELECT * FROM "+viewName)
+	if err != nil {
+	  return err
+	}
+	defer viewRows.Close()
+
+	err = printRows(viewRows)
+	if err != nil {
+	  return err
+	}
+
+```
+*/
+func Example() {
+	db, err := sql.Open("duckdb", "")
+	if err != nil {
+		panic(err)
+	}
+	defer func() {
+		_ = db.Close()
+	}()
+
+	conn, err := db.Conn(context.Background())
+	if err != nil {
+		panic(err)
+	}
+	defer func() {
+		_ = conn.Close()
+	}()
+
+	err = conn.Raw(func(driverConn any) error {
+		innerConn, ok := driverConn.(driver.Conn)
+		if !ok {
+			return fmt.Errorf("driverConn is not a driver.Conn")
+		}
+
+		ar, err := duckdb.NewArrowFromConn(innerConn)
+		if err != nil {
+			return err
+		}
+
+		pool := memory.NewGoAllocator()
+		schema := arrow.NewSchema(
+			[]arrow.Field{
+				{Name: "f1_i32", Type: arrow.PrimitiveTypes.Int32},
+				{Name: "f2_f64", Type: arrow.PrimitiveTypes.Float64},
+				{Name: "f3_str", Type: arrow.BinaryTypes.String},
+			},
+			nil,
+		)
+
+		b := array.NewRecordBuilder(pool, schema)
+		defer b.Release()
+
+		b.Field(0).(*array.Int32Builder).AppendValues([]int32{1, 2, 3}, nil)
+		b.Field(0).(*array.Int32Builder).AppendValues([]int32{4, 5}, []bool{false, true})
+		b.Field(1).(*array.Float64Builder).AppendValues([]float64{1, 2, 3, 4, 5}, nil)
+		b.Field(2).(*array.StringBuilder).AppendValues([]string{"a", "b", "c", "d", "e"}, nil)
+
+		rec1 := b.NewRecord()
+		defer rec1.Release()
+
+		rr, err := array.NewRecordReader(schema, []arrow.Record{rec1})
+		if err != nil {
+			return err
+		}
+		defer rr.Release()
+
+		release, err := ar.RegisterView(rr, "arrow_table")
+		if err != nil {
+			return err
+		}
+		defer release()
+
+		// Query the table to verify the data.
+		rows, err := db.QueryContext(context.Background(), `SELECT * FROM arrow_table`)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+
+		err = printRows(rows)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	// Output:
+	// f1_i32	f2_f64	f3_str
+	// [1]	[1]	[a]
+	// [2]	[2]	[b]
+	// [3]	[3]	[c]
+	// NULL	[4]	[d]
+	// [5]	[5]	[e]
+	//
+}
+
+func printRows(rows *sql.Rows) error {
+	columns, err := rows.Columns()
+	if err != nil {
+		return err
+	}
+
+	colNum := len(columns)
+	values := make([]interface{}, colNum)
+	for i, col := range columns {
+		if i > 0 {
+			fmt.Printf("\t")
+		}
+		values[i] = new(sql.RawBytes)
+		fmt.Printf("%s", col)
+	}
+
+	for rows.Next() {
+		err = rows.Scan(values...)
+		if err != nil {
+			return err
+		}
+		fmt.Println()
+		for i := range columns {
+			if i > 0 {
+				fmt.Printf("\t")
+			}
+			if len(*values[i].(*sql.RawBytes)) == 0 {
+				fmt.Printf("NULL")
+			} else {
+				fmt.Printf("[%s]", string(*values[i].(*sql.RawBytes)))
+			}
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
The following error was happening on replication of simple updates on 1 DB, while on others it was working OK:
```
Failed to flush changelog: Invalid Input Error: Invalid unicode (byte sequence mismatch) detected in segment statistics update
```

With the help of the function from the first commit I was able to get precisely the content of the Apache Arrow delta buffers and discover that the issue is happening on some servers and not others because of their different server IDs.
What was happening is that `binary.BigEndian.PutUint32()` from the server ID is generating a byte slice containing invalid UTF-8 characters, which later breaks [the query here](https://github.com/karsov/myduckserver/blob/7c874c5d3f8cc0afcc259911c606f6883c646e10/delta/controller.go#L421). Because for different server IDs we get different byte slices for most servers we don't observe the issue but for some we observe it. Basically, we are lucky we found the issue so early.

I don't see a reason for using `binary.BigEndian.PutUint32()` (not used anywhere really) that's why now I'm just putting the server ID and domain ID in `txnServer` and `txnTag`. Maybe we don't need these fields at all but keeping them for now just in case.